### PR TITLE
Fix SubnetProxy fuzzy match

### DIFF
--- a/src/main/java/com/cells/parts/subnetproxy/PartSubnetProxyFront.java
+++ b/src/main/java/com/cells/parts/subnetproxy/PartSubnetProxyFront.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.List;
@@ -2338,9 +2337,10 @@ public class PartSubnetProxyFront extends AEBasePart
      * Only called when {@code filtersDirty} is true (config/upgrade change).
      * Uses AE2's native {@link IItemList#findPrecise} for precise matching,
      * which leverages interned {@code AESharedItemStack} reference lookups
-     * (identity hash, zero NBT cost). Fuzzy matching uses a {@code Map<Item,
-     * List<IAEItemStack>>} index for O(1) candidate lookup + damage-range
-     * comparisons.
+     * (identity hash, zero NBT cost). Fuzzy matching delegates to AE2's native
+     * {@link IItemList#findFuzzy}, matching the behavior of most fuzzy-capable
+     * AE2 parts: ordinary items match by {@code Item}, while damageable items
+     * also honor {@link FuzzyMode} durability ranges.
      */
     private void rebuildFilters() {
         this.filtersDirty = false;
@@ -2370,10 +2370,6 @@ public class PartSubnetProxyFront extends AEBasePart
         // so a Set<Fluid> gives us O(1) lookup with the same semantics.
         Set<Fluid> fuzzyFluidIndex = hasFuzzy ? new HashSet<>() : null;
 
-        // For fuzzy item matching, we index filters by Item to avoid O(F) per-item scans.
-        // Only the filters for the matching Item need to be checked per incoming stack.
-        Map<Item, List<IAEItemStack>> fuzzyItemIndex = hasFuzzy ? new HashMap<>() : null;
-
         for (int i = 0; i < totalSlots; i++) {
             ItemStack stack = this.config.getStackInSlot(i);
             if (stack.isEmpty()) continue;
@@ -2393,11 +2389,6 @@ public class PartSubnetProxyFront extends AEBasePart
                 if (aeFilter != null) {
                     itemFilterList.add(aeFilter);
                     hasItemFilters = true;
-
-                    if (hasFuzzy) {
-                        // Index by Item for O(1) lookup of candidate filters per incoming stack
-                        fuzzyItemIndex.computeIfAbsent(stack.getItem(), k -> new ArrayList<>()).add(aeFilter);
-                    }
                 }
             }
         }
@@ -2406,25 +2397,14 @@ public class PartSubnetProxyFront extends AEBasePart
         if (!hasItemFilters && !hasInverter) {
             // No filters + whitelist = pass everything
             this.itemHandler.setFilter(null);
-        } else if (hasFuzzy && fuzzyItemIndex != null && !fuzzyItemIndex.isEmpty()) {
-            // Fuzzy matching: look up candidate filters by Item, then check damage range.
-            // O(1) map lookup + O(K) fuzzy checks where K = filters for the same Item.
-            // There should not be many filters per Item, except with metadata-items (Thermal Expansion materials, etc.)
+        } else if (hasFuzzy && hasItemFilters) {
+            // Match AE2's native fuzzy partition semantics. For most ordinary
+            // items this widens matching to all stacks with the same Item;
+            // damageable items are additionally grouped by FuzzyMode.
             this.itemHandler.setFilter(aeStack -> {
                 if (aeStack == null) return false;
 
-                Item item = aeStack.getDefinition().getItem();
-                List<IAEItemStack> candidates = fuzzyItemIndex.get(item);
-
-                boolean matchesAny = false;
-                if (candidates != null) {
-                    for (IAEItemStack aeFilter : candidates) {
-                        if (aeStack.fuzzyComparison(aeFilter, fuzzyMode)) {
-                            matchesAny = true;
-                            break;
-                        }
-                    }
-                }
+                boolean matchesAny = !itemFilterList.findFuzzy(aeStack, fuzzyMode).isEmpty();
 
                 return hasInverter != matchesAny;
             });


### PR DESCRIPTION
# Summary

Subnet Proxy currently uses `AEItemStack.fuzzyComparison()` for fuzzy item filters.

That can make many ordinary non-damageable whitelisted items stop matching entirely as soon as a Fuzzy Card is installed.

Fluid, gas, and essentia behavior is unchanged.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore/Refactor (no functional changes)
- [ ] Documentation update only

## Related issues

N/A

## What changed

Replace that logic with AE2's native `findFuzzy()` matching for item filters, aligning Subnet Proxy with the fuzzy behavior used by most AE2 fuzzy-capable parts.

## How to test

1. Set up a Subnet Proxy between two AE2 networks.
2. Add an ordinary non-damageable item to the item filter and confirm matching items are visible from the front network.
3. Install a Fuzzy Card.
4. Verify those items still match and remain visible instead of disappearing.


## Checklist
- [x] I built the project locally with Java 8 using `gradle build`.
- [x] I updated documentation (README/DEVELOPMENT.md) as needed.
- [x] I followed the existing code style.
- [x] I did not include secrets or private data.
- [x] If touching `mcmod.info`, it remains valid and accurate.
- [x] I searched for existing PRs/issues that cover this change.

## Additional context

Some comments generated by AI.